### PR TITLE
Fixed nodeSelector at customized ingresscontroller

### DIFF
--- a/customisation/99-ingress-controller.yaml
+++ b/customisation/99-ingress-controller.yaml
@@ -9,4 +9,5 @@ spec:
     type: HostNetwork
   nodePlacement:
     nodeSelector:
-      node-role.kubernetes.io/master: ''
+      matchLabels:
+        node-role.kubernetes.io/master: ''


### PR DESCRIPTION
`matchLabels` was not present at `nodeSelector` property of `nodePlacement` setting on customized ingress controller. Instead of causing a failure, this was silently ignored by placing an empty `nodeSelector`.