### PR TITLE
fix: properly catch upstream dns

### DIFF
--- a/staticpods/coredns.yml
+++ b/staticpods/coredns.yml
@@ -23,7 +23,7 @@ spec:
     - "-c"
     - |
       #/bin/sh
-      NAMESERVER=$(tail -1 /etc/resolv.conf | grep -v 'fe80::' | sed 's/nameserver //')
+      NAMESERVER=$(grep -v 'fe80::' /etc/resolv.conf | tail -1 | sed 's/nameserver //')
       grep -q "NAMESERVER" /etc/coredns/Corefile
       if [ "$?" != "0" ] ; then
         exit 0


### PR DESCRIPTION
* tailing first and then excluding the ipv6 DNS, produces an empty
output, changing the order on the pipe seems to fix the issue