### PR TITLE
dnsmasq wildcard configuration fixed

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -163,7 +163,7 @@ if [[ "$platform" == *virt* ]] || [[ "$platform" == *openstack* ]] || [[ "$platf
     fi
   elif [ ! -f /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf ] || [ "$(grep $api_ip /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf)" == "" ] ; then
     echo -e "${BLUE}Adding wildcard for apps.$cluster.$domain in NetworkManager...${NC}"
-    sudo sh -c "echo server=/apps.$cluster.$domain/$api_ip > /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf"
+    sudo sh -c "echo address=/apps.$cluster.$domain/$api_ip > /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf"
     sudo systemctl reload NetworkManager
   fi
   if [ "$platform" == "kubevirt" ] || [ "$platform" == "openstack" ] || [ "$platform" == "vsphere" ]; then

--- a/get_upstream_installer.sh
+++ b/get_upstream_installer.sh
@@ -4,4 +4,4 @@ source common.sh
 
 echo -e "${BLUE}Downloading latest openshift-install from registry.svc.ci.openshift.org in current directory${NC}"
 VERSION=$(curl -s https://api.github.com/repos/openshift/okd/releases| grep tag_name | sed 's/.*: "\(.*\)",/\1/' | sort | tail -1)
-curl -s https://github.com/openshift/okd/releases/download/$VERSION/openshift-install-$INSTALLSYSTEM-$VERSION.tar.gz
+curl -Ls https://github.com/openshift/okd/releases/download/$VERSION/openshift-install-$INSTALLSYSTEM-$VERSION.tar.gz | tar zxvf - openshift-install -C . 


### PR DESCRIPTION
This PR fixes the access to the application exposed by the router from outside the OCP cluster. Basically, redirect apps wildcard domain to the haproxy which is balancing between routers running on workers.

Remember also to configure NetworManager to enable dnsmasq.