### PR TITLE
Fixed conditional when checking if parameter upstream is set

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -163,7 +163,7 @@ if [[ "$platform" == *virt* ]] || [[ "$platform" == *openstack* ]] || [[ "$platf
     fi
   elif [ ! -f /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf ] || [ "$(grep $api_ip /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf)" == "" ] ; then
     echo -e "${BLUE}Adding wildcard for apps.$cluster.$domain in NetworkManager...${NC}"
-    sudo sh -c "echo server=/apps.$cluster.$domain/$api_ip > /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf"
+    sudo sh -c "echo address=/apps.$cluster.$domain/$api_ip > /etc/NetworkManager/dnsmasq.d/$cluster.$domain.conf"
     sudo systemctl reload NetworkManager
   fi
   if [ "$platform" == "kubevirt" ] || [ "$platform" == "openstack" ] || [ "$platform" == "vsphere" ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -63,7 +63,7 @@ fi
 which openshift-install >/dev/null 2>&1
 if [ "$?" != "0" ]; then
   if [ "$( grep registry.svc.ci.openshift.org $pull_secret )" != "" ] ; then
-    if [ "$upstream" == "true" ] ; then
+    if [ "$upstream" == "True" ] ; then
       get_upstream_installer.sh
     else
       get_nightly_installer.sh
@@ -73,7 +73,7 @@ if [ "$?" != "0" ]; then
   fi
 fi
 INSTALLER_VERSION=$(openshift-install version | head -1 | cut -d" " -f2)
-if [ "$upstream" == "true" ] ; then
+if [ "$upstream" == "True" ] ; then
   COS_VERSION="latest"
   COS_TYPE="fcos"
 else

--- a/get_upstream_installer.sh
+++ b/get_upstream_installer.sh
@@ -4,4 +4,4 @@ source common.sh
 
 echo -e "${BLUE}Downloading latest openshift-install from registry.svc.ci.openshift.org in current directory${NC}"
 VERSION=$(curl -s https://api.github.com/repos/openshift/okd/releases| grep tag_name | sed 's/.*: "\(.*\)",/\1/' | sort | tail -1)
-curl -s https://github.com/openshift/okd/releases/download/$VERSION/openshift-install-$INSTALLSYSTEM-$VERSION.tar.gz
+curl -Ls https://github.com/openshift/okd/releases/download/$VERSION/openshift-install-$INSTALLSYSTEM-$VERSION.tar.gz | tar zxvf - openshift-install -C . 


### PR DESCRIPTION
This PR fixes two conditionals when checking if upstream is set to true or not. Since the python script set it to **T**rue either you set it to true or True then you need to check against that string in your deploy.sh

python gather_env.py parameters.yml
export cluster=ocp4
export numcpus=4
export autostart=False
export network=default
export master_memory=16384
export worker_memory=8192
export bootstrap_memory=8192
export disk_size=30
export domain=knilabs.com
export masters=1
export workers=1
export api_ip=192.168.122.2
**export upstream=True**
export image=fedora-coreos-30.20191014.0-qemu.x86_64.qcow2

Another way to correct this issue is always uppercase both the $upstream value and the true string in the conditional.
